### PR TITLE
Add public & private routes to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,11 @@ output "public_subnets" {
 output "vpc_id" {
   value = "${aws_vpc.mod.id}"
 }
+
+output "public_route_table_id" {
+  value = "${aws_route_table.public.id}"
+}
+
+output "private_route_table_id" {
+  value = "${aws_route_table.private.id}"
+}


### PR DESCRIPTION
As per the previous pull request, but adding public route tables too.
I didnt want to address the issues in your comment on the other PR @antonbabenko, i feel they are out of scope of this.
I simply want to access the outputs of the created resources.
